### PR TITLE
fix(renovate): use bump strategy for phpunit to prevent widen

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -108,7 +108,7 @@
         "phpunit/phpunit"
       ],
       "enabled": true,
-      "rangeStrategy": "replace"
+      "rangeStrategy": "auto"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -90,15 +90,25 @@
       "enabled": false
     },
     {
-      "description": "phpunit と composer-bin-plugin は更新する",
+      "description": "composer-bin-plugin は更新する",
       "matchFileNames": [
         "composer.json"
       ],
       "matchPackageNames": [
-        "phpunit/phpunit",
         "bamarni/composer-bin-plugin"
       ],
       "enabled": true
+    },
+    {
+      "description": "phpunit は bump 戦略で更新する（widen を防止）",
+      "matchFileNames": [
+        "composer.json"
+      ],
+      "matchPackageNames": [
+        "phpunit/phpunit"
+      ],
+      "enabled": true,
+      "rangeStrategy": "bump"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -108,7 +108,7 @@
         "phpunit/phpunit"
       ],
       "enabled": true,
-      "rangeStrategy": "bump"
+      "rangeStrategy": "replace"
     }
   ]
 }


### PR DESCRIPTION
PHPUnit のバージョン制約が || で追加され続ける問題を防止するため、
rangeStrategy を bump に設定。

https://claude.ai/code/session_0126cjbpGWgphsZegY1fMrzi
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/naokitsuchiya/raydipsrcontainer/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined automated dependency update configuration by splitting update rules and applying distinct version bump strategies for finer control and to reduce unintended version widening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->