### PR TITLE
chore(ci): replace deprecated codecov/test-results-action with codecov-action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -91,6 +91,7 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           report_type: test_results
+          files: junit.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage report

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,8 +88,9 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
+          report_type: test_results
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage report

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -92,10 +92,8 @@ jobs:
         with:
           report_type: test_results
           files: junit.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage report
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false  # Don't fail if coverage upload fails


### PR DESCRIPTION
## Summary

- `codecov/test-results-action@v1` が非推奨となり `codecov/codecov-action@v5` に統合されたため、CIワークフローを更新
- `report_type: test_results` パラメータを追加し、既存のカバレッジアップロードと同じアクションを使用

## Test plan

- [ ] CIが正常に実行されること
- [ ] PHPUnitジョブで非推奨警告が出なくなること
- [ ] テスト結果がCodecovに正常にアップロードされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/naokitsuchiya/raydipsrcontainer/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration for test results: switched to a newer upload action and added explicit report-type and file parameters to improve test-reporting and artifact coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->