### PR TITLE
chore(renovate): pin psalm/plugin-phpunit to <0.20

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -61,6 +61,16 @@
       "automerge": true
     },
     {
+      "description": "psalm/plugin-phpunit 0.20+ requires Psalm 7; pin until Psalm 7 stable",
+      "matchFileNames": [
+        "vendor-bin/**"
+      ],
+      "matchPackageNames": [
+        "psalm/plugin-phpunit"
+      ],
+      "allowedVersions": "<0.20"
+    },
+    {
       "description": "PHPMD",
       "matchFileNames": [
         "vendor-bin/**"


### PR DESCRIPTION
## Summary
- Renovate の grouped psalm-packages 更新で `psalm/plugin-phpunit` が 0.20.x に上がると、依存する `psalm/psalm-plugin-api 0.1.0` が `vimeo/psalm <7.0.0` を明示的に conflict するため、Psalm 6 系を使っている間は必ず壊れる (PR #50 の CI 失敗原因)
- `psalm/plugin-phpunit` のみ `allowedVersions: "<0.20"` を追加し、Psalm 7 stable 採用までは 0.19.x に据え置く
- 既存の psalm-packages グループ (vimeo/psalm + plugin-phpunit) はそのまま。Psalm 7 stable を採用したらこの pin を外せば OK

ブランチ名を `renovate/reconfigure` にしているので、Renovate が自動で設定の妥当性を検証します。

## Test plan
- [ ] Renovate の次回実行で `psalm/plugin-phpunit` の 0.20.x アップデート PR が作成されないことを確認
- [ ] `vimeo/psalm` の 6.x 系 patch/minor 更新は従来通り PR 化されることを確認

https://claude.ai/code/session_01WKkf1V9BgeYaRB8VG7U5EY
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/naokitsuchiya/raydipsrcontainer/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
